### PR TITLE
Remove redundant "branch": "stable"

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -410,7 +410,6 @@
         "--env=LIBO_FLATPAK=1"
     ], 
     "command": "/app/libreoffice/program/soffice", 
-    "branch": "stable", 
     "runtime-version": "3.24", 
     "runtime": "org.gnome.Platform", 
     "sdk": "org.gnome.Sdk"

--- a/org.libreoffice.LibreOffice.json.in
+++ b/org.libreoffice.LibreOffice.json.in
@@ -1,6 +1,5 @@
 {
     "app-id": "org.libreoffice.LibreOffice",
-    "branch": "stable",
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.24",
     "sdk": "org.gnome.Sdk",


### PR DESCRIPTION
Flathub adds it anyway by default (passing --default-branch=stable to
flatpak-builder), and this will help harmonizing this manifest with the one in
<https://gerrit.libreoffice.org/gitweb?p=dev-tools.git;a=blob;f=flatpak/build.sh>.